### PR TITLE
Fix FN

### DIFF
--- a/djradicale/models.py
+++ b/djradicale/models.py
@@ -98,10 +98,9 @@ class DBItem(models.Model):
         return self.name
 
     def _get_field(self, field):
-        lines = filter(
-            lambda x: x.startswith(field + ':'), self.text.split('\n'))
-        if lines:
-            return next(lines)[len(field + ':'):]
+        for line in self.text.split('\n'):
+            if line.startswith(field + ':'):
+                return line[len(field + ':'):]
 
     @property
     def fn(self):


### PR DESCRIPTION
kalendar_kontakty_1  |   File "/usr/lib/python3.5/site-packages/django/contrib/admin/utils.py", line 308, in _get_non_gfk_field
kalendar_kontakty_1  |     field = opts.get_field(name)
kalendar_kontakty_1  |   File "/usr/lib/python3.5/site-packages/django/db/models/options.py", line 619, in get_field
kalendar_kontakty_1  |     raise FieldDoesNotExist('%s has no field named %r' % (self.object_name, field_name))
kalendar_kontakty_1  | django.core.exceptions.FieldDoesNotExist: DBItem has no field named 'fn'
kalendar_kontakty_1  |
kalendar_kontakty_1  | During handling of the above exception, another exception occurred:
kalendar_kontakty_1  |
kalendar_kontakty_1  | Traceback (most recent call last):
kalendar_kontakty_1  |   File "./modules/djradicale/models.py", line 107, in _get_field
kalendar_kontakty_1  |     return next(lines)[len(field + ':'):]
kalendar_kontakty_1  | StopIteration
kalendar_kontakty_1  | None
